### PR TITLE
10 seminar 7주차 세미나

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,4 +29,8 @@ dependencies {
 
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'com.auth0:java-jwt:4.4.0'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }

--- a/src/main/java/org/sopt/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package org.sopt.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("SOPT API")
+                        .description("SOPT 과제 API 문서")
+                        .version("v1.0.0")
+                        .contact(new Contact()
+                                .name("byunheemin")
+                                .email("byunhm02@gmail.com")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("로컬 서버")
+                ));
+    }
+}

--- a/src/main/java/org/sopt/controller/CommentController.java
+++ b/src/main/java/org/sopt/controller/CommentController.java
@@ -1,0 +1,80 @@
+package org.sopt.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.dto.CommentResponseDto;
+import org.sopt.dto.CreateCommentRequestDto;
+import org.sopt.dto.UpdateCommentRequestDto;
+import org.sopt.global.ApiResponseDto;
+import org.sopt.service.CommentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 작성
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<Long>> createComment(
+            @Valid @RequestBody CreateCommentRequestDto request) {
+
+        Long commentId = commentService.createComment(request);
+        ApiResponseDto<Long> response = ApiResponseDto.success(commentId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 댓글 단건 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<CommentResponseDto>> getComment(
+            @PathVariable Long id) {
+
+        CommentResponseDto comment = commentService.getComment(id);
+        ApiResponseDto<CommentResponseDto> response = ApiResponseDto.success(comment);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 특정 게시글의 모든 댓글 조회
+    @GetMapping("/article/{articleId}")
+    public ResponseEntity<ApiResponseDto<List<CommentResponseDto>>> getCommentsByArticle(
+            @PathVariable Long articleId) {
+
+        List<CommentResponseDto> comments = commentService.getCommentsByArticle(articleId);
+        ApiResponseDto<List<CommentResponseDto>> response = ApiResponseDto.success(comments);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 댓글 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<Void>> updateComment(
+            @PathVariable Long id,
+            @RequestParam Long memberId,
+            @Valid @RequestBody UpdateCommentRequestDto request) {
+
+        commentService.updateComment(id, memberId, request);
+        ApiResponseDto<Void> response = ApiResponseDto.success(null);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteComment(
+            @PathVariable Long id,
+            @RequestParam Long memberId) {
+
+        commentService.deleteComment(id, memberId);
+        ApiResponseDto<Void> response = ApiResponseDto.success(null);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/sopt/domain/Article.java
+++ b/src/main/java/org/sopt/domain/Article.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "articles")
@@ -29,6 +31,10 @@ public class Article {
     private String title;
 
     private String content;
+
+    @OneToMany(mappedBy = "article", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
+
 
     public Article(Member member, Category category, String title, String content) {
         this.member = member;

--- a/src/main/java/org/sopt/domain/Article.java
+++ b/src/main/java/org/sopt/domain/Article.java
@@ -9,7 +9,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "articles")
+@Table(name = "articles", indexes = {
+        @Index(name = "idx_article_member_id", columnList = "memberId"),
+        @Index(name = "idx_article_created_date", columnList = "createdDate"),
+        @Index(name = "idx_article_category", columnList = "category"),
+        @Index(name = "idx_article_category_created", columnList = "category, createdDate")
+})
 @Getter
 @NoArgsConstructor
 public class Article {

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -7,7 +7,11 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "comments")
+@Table(name = "comments", indexes = {
+        @Index(name = "idx_comment_article_id", columnList = "articleId"),
+        @Index(name = "idx_comment_member_id", columnList = "memberId"),
+        @Index(name = "idx_comment_article_created", columnList = "articleId, createdDate")
+})
 @Getter
 @NoArgsConstructor
 public class Comment {

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -1,0 +1,42 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name = "memberId",nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="articleId",nullable = false)
+    private Article article;
+
+    private LocalDate createdDate;
+
+    public Comment(Member member, Article article, String content) {
+        this.member = member;
+        this.article = article;
+        this.content = content;
+        this.createdDate = LocalDate.now();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/src/main/java/org/sopt/dto/ArticleResponseDto.java
+++ b/src/main/java/org/sopt/dto/ArticleResponseDto.java
@@ -4,6 +4,8 @@ import org.sopt.domain.Article;
 import org.sopt.domain.Category;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public record ArticleResponseDto(
         Long id,
@@ -12,7 +14,8 @@ public record ArticleResponseDto(
         Category category,
         LocalDate createdDate,
         String title,
-        String content
+        String content,
+        List<CommentResponseDto> comments
 ) {
     public static ArticleResponseDto from(Article article) {
         return new ArticleResponseDto(
@@ -22,7 +25,10 @@ public record ArticleResponseDto(
                 article.getCategory(),
                 article.getCreatedDate(),
                 article.getTitle(),
-                article.getContent()
+                article.getContent(),
+                article.getComments().stream()
+                        .map(CommentResponseDto::from)
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/org/sopt/dto/CommentResponseDto.java
+++ b/src/main/java/org/sopt/dto/CommentResponseDto.java
@@ -1,0 +1,25 @@
+package org.sopt.dto;
+
+import org.sopt.domain.Comment;
+
+import java.time.LocalDate;
+
+public record CommentResponseDto(
+        Long id,
+        Long memberId,
+        String memberName,
+        Long articleId,
+        String content,
+        LocalDate createdDate
+) {
+    public static CommentResponseDto from(Comment comment) {
+        return new CommentResponseDto(
+                comment.getId(),
+                comment.getMember().getId(),
+                comment.getMember().getName(),
+                comment.getArticle().getId(),
+                comment.getContent(),
+                comment.getCreatedDate()
+        );
+    }
+}

--- a/src/main/java/org/sopt/dto/CreateCommentRequestDto.java
+++ b/src/main/java/org/sopt/dto/CreateCommentRequestDto.java
@@ -1,0 +1,17 @@
+package org.sopt.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.NotBlank;
+
+public record CreateCommentRequestDto(
+        @NotNull(message = "회원 ID는 필수입니다.")
+        Long memberId,
+
+        @NotNull(message = "게시글 ID는 필수입니다.")
+        Long articleId,
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 300, message = "댓글은 300자 이내로 작성해주세요.")
+        String content
+) {}

--- a/src/main/java/org/sopt/dto/UpdateCommentRequestDto.java
+++ b/src/main/java/org/sopt/dto/UpdateCommentRequestDto.java
@@ -1,0 +1,10 @@
+package org.sopt.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCommentRequestDto(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 300, message = "댓글은 300자 이내로 작성해주세요.")
+        String content
+) {}

--- a/src/main/java/org/sopt/exception/CommentNotFoundException.java
+++ b/src/main/java/org/sopt/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package org.sopt.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(Long commentId) {
+        super("댓글을 찾을 수 없습니다. ID: " + commentId);
+    }
+}

--- a/src/main/java/org/sopt/exception/UnauthorizedException.java
+++ b/src/main/java/org/sopt/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package org.sopt.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/sopt/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/GlobalExceptionHandler.java
@@ -23,6 +23,24 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
+    // 404: 댓글을 찾을 수 없음
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleCommentNotFoundException(
+            CommentNotFoundException e) {
+
+        ApiResponseDto<Void> response = ApiResponseDto.error(404, e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    // 403: 댓글 수정 권한 없음
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleUnauthorizedException(
+            UnauthorizedException e) {
+
+        ApiResponseDto<Void> response = ApiResponseDto.error(403, e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
     // 409: 이메일 중복
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ApiResponseDto<Void>> handleDuplicateEmailException(

--- a/src/main/java/org/sopt/repository/ArticleRepository.java
+++ b/src/main/java/org/sopt/repository/ArticleRepository.java
@@ -1,10 +1,31 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Article;
+import org.sopt.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     boolean existsByTitle(String title);
+    // N+1 문제 해결: Member를 fetch join으로 한번에 조회
+    @Query("SELECT a FROM Article a JOIN FETCH a.member ORDER BY a.createdDate DESC")
+    List<Article> findAllWithMember();
+
+    // 카테고리별 조회 (인덱스 활용)
+    @Query("SELECT a FROM Article a JOIN FETCH a.member WHERE a.category = :category ORDER BY a.createdDate DESC")
+    List<Article> findByCategoryWithMember(@Param("category") Category category);
+
+    // 게시글 상세 조회 시 Member와 Comments를 한번에 조회 (N+1 해결)
+    @Query("SELECT DISTINCT a FROM Article a " +
+            "JOIN FETCH a.member " +
+            "LEFT JOIN FETCH a.comments c " +
+            "LEFT JOIN FETCH c.member " +
+            "WHERE a.id = :id")
+    Optional<Article> findByIdWithMemberAndComments(@Param("id") Long id);
 }

--- a/src/main/java/org/sopt/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByArticleId(Long articleId);
+}

--- a/src/main/java/org/sopt/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/repository/CommentRepository.java
@@ -2,8 +2,20 @@ package org.sopt.repository;
 
 import org.sopt.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleId(Long articleId);
+
+    // 인덱스 사용, articleId로 조회
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.article.id = :articleId ORDER BY c.createdDate DESC")
+    List<Comment> findByArticleIdWithMember(@Param("articleId") Long articleId);
+
+    // 댓글 단건 조회 시 Member도 함께 조회
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.id = :id")
+    Optional<Comment> findByIdWithMember(@Param("id") Long id);
 }

--- a/src/main/java/org/sopt/service/ArticleServiceImpl.java
+++ b/src/main/java/org/sopt/service/ArticleServiceImpl.java
@@ -2,6 +2,7 @@ package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Article;
+import org.sopt.domain.Category;
 import org.sopt.domain.Member;
 import org.sopt.dto.ArticleResponseDto;
 import org.sopt.dto.ArticleSummaryDto;
@@ -11,6 +12,7 @@ import org.sopt.exception.DuplicateTitleException;
 import org.sopt.exception.MemberNotFoundException;
 import org.sopt.repository.ArticleRepository;
 import org.sopt.repository.MemberRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,7 +55,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     public ArticleResponseDto getArticle(Long articleId) {
 
-        Article article = articleRepository.findById(articleId)
+        Article article = articleRepository.findByIdWithMemberAndComments(articleId)
                 .orElseThrow(() -> new ArticleNotFoundException(articleId));
 
         return ArticleResponseDto.from(article);
@@ -61,7 +63,8 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public List<ArticleSummaryDto> getAllArticles() {
-        return articleRepository.findAll().stream()
+
+        return articleRepository.findAllWithMember().stream()
                 .map(ArticleSummaryDto::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/sopt/service/CommentService.java
+++ b/src/main/java/org/sopt/service/CommentService.java
@@ -1,0 +1,14 @@
+package org.sopt.service;
+
+import org.sopt.dto.CommentResponseDto;
+import org.sopt.dto.CreateCommentRequestDto;
+import org.sopt.dto.UpdateCommentRequestDto;
+import java.util.List;
+
+public interface CommentService {
+    Long createComment(CreateCommentRequestDto req);
+    CommentResponseDto getComment(Long commentId);
+    List<CommentResponseDto> getCommentsByArticle(Long articleId);
+    void updateComment(Long commentId, Long memberId, UpdateCommentRequestDto req);
+    void deleteComment(Long commentId, Long memberId);
+}

--- a/src/main/java/org/sopt/service/CommentServiceImpl.java
+++ b/src/main/java/org/sopt/service/CommentServiceImpl.java
@@ -49,7 +49,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public CommentResponseDto getComment(Long commentId) {
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentNotFoundException(commentId));
 
         return CommentResponseDto.from(comment);

--- a/src/main/java/org/sopt/service/CommentServiceImpl.java
+++ b/src/main/java/org/sopt/service/CommentServiceImpl.java
@@ -1,0 +1,97 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Article;
+import org.sopt.domain.Comment;
+import org.sopt.domain.Member;
+import org.sopt.dto.CommentResponseDto;
+import org.sopt.dto.CreateCommentRequestDto;
+import org.sopt.dto.UpdateCommentRequestDto;
+import org.sopt.exception.ArticleNotFoundException;
+import org.sopt.exception.CommentNotFoundException;
+import org.sopt.exception.MemberNotFoundException;
+import org.sopt.exception.UnauthorizedException;
+import org.sopt.repository.ArticleRepository;
+import org.sopt.repository.CommentRepository;
+import org.sopt.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final ArticleRepository articleRepository;
+
+    @Override
+    @Transactional
+    public Long createComment(CreateCommentRequestDto req) {
+        // 회원 확인
+        Member member = memberRepository.findByIdAndIsDeletedFalse(req.memberId())
+                .orElseThrow(() -> new MemberNotFoundException(req.memberId()));
+
+        // 게시글 확인
+        Article article = articleRepository.findById(req.articleId())
+                .orElseThrow(() -> new ArticleNotFoundException(req.articleId()));
+
+        // 댓글 생성
+        Comment comment = new Comment(member, article, req.content());
+        Comment savedComment = commentRepository.save(comment);
+
+        return savedComment.getId();
+    }
+
+    @Override
+    public CommentResponseDto getComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        return CommentResponseDto.from(comment);
+    }
+
+    @Override
+    public List<CommentResponseDto> getCommentsByArticle(Long articleId) {
+        // 게시글 존재 확인
+        if (!articleRepository.existsById(articleId)) {
+            throw new ArticleNotFoundException(articleId);
+        }
+
+        return commentRepository.findByArticleId(articleId).stream()
+                .map(CommentResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void updateComment(Long commentId, Long memberId, UpdateCommentRequestDto req) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        // 작성자 확인
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new UnauthorizedException("댓글 수정 권한이 없습니다.");
+        }
+
+        comment.updateContent(req.content());
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        // 작성자 확인
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new UnauthorizedException("댓글 삭제 권한이 없습니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 앱잼신청
- [x] 기경 및 밋업 적극적 참여
- [x] 댓글기능 추가

<br>

### 선택과제
- [ ] 캐싱으로 성능 최적화
- [x] 대용량 데이터 처리 및 정렬 최적화
- [ ] 인프라 설계 시각화
- [ ] 테스트코드 도입

<br>

### **구현한 내용에 대해서 설명해주세요**
- 댓글 CRUD 기능 구현
  - 댓글 작성, 조회, 수정, 삭제
  - 게시글 상세 조회 시 댓글 목록 함께 반환
  - 게시글별 댓글 목록 조회
- Swagger UI 적용으로 API 문서화

#### 1. Comment 엔티티
```java
@Entity
@Table(name = "comments", indexes = {
    @Index(name = "idx_comment_article_id", columnList = "articleId"),
    @Index(name = "idx_comment_member_id", columnList = "memberId"),
    @Index(name = "idx_comment_article_created", columnList = "articleId, createdDate")
})
public class Comment {
    // 300자 제한
    @Column(nullable = false, length = 300)
    private String content;
}
```

#### 2. Repository 최적화
```java
// N+1 문제 해결: Fetch Join 활용
@Query("SELECT a FROM Article a JOIN FETCH a.member ORDER BY a.createdDate DESC")
List findAllWithMember();

@Query("SELECT DISTINCT a FROM Article a " +
       "JOIN FETCH a.member " +
       "LEFT JOIN FETCH a.comments c " +
       "LEFT JOIN FETCH c.member " +
       "WHERE a.id = :id")
Optional findByIdWithMemberAndComments(@Param("id") Long id);
```


#### 3. Validation
```java
// 댓글 300자 제한
@NotBlank(message = "댓글 내용은 필수입니다.")
@Size(max = 300, message = "댓글은 300자 이내로 작성해주세요.")
String content;
```

#### 5. API 문서화
- Swagger UI로 API 테스트 가능

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
**고민한 지점**
- 어느 컬럼에 인덱스를 추가해야 효과적일까?
- 복합 인덱스의 컬럼 순서는 어떻게 정해야 할까?
- 인덱스 추가로 인한 쓰기 성능 저하는 감수할 만한가?

**적용한 인덱스**
```sql
-- Article 테이블
idx_article_member_id (memberId)              -- JOIN 최적화
idx_article_created_date (createdDate)        -- 정렬 최적화
idx_article_category (category)               -- 카테고리 필터링
idx_article_category_created (category, createdDate)  -- 복합 조건 최적화

-- Comment 테이블
idx_comment_article_id (articleId)            -- 게시글별 댓글 조회
idx_comment_member_id (memberId)              -- JOIN 최적화
idx_comment_article_created (articleId, createdDate)  -- 댓글 정렬
```

**트레이드오프 분석**

✅ **장점**
- 조회 성능 향상 
- ORDER BY 정렬 속도 향상
- JOIN 성능 개선
- 읽기 중심 서비스에 최적화

❌ **단점**
- 쓰기 성능 저하 
  - INSERT 시 인덱스 테이블도 함께 갱신
- 저장 공간 증가 
  - 100만 건 기준: 원본 500MB + 인덱스 200MB
- 인덱스 유지보수 비용 발생
- 메모리 사용량 증가


#### 3. N+1 문제 해결
**문제 상황**
```java
// 기존 코드 - N+1 발생
List articles = articleRepository.findAll();
// 1번의 쿼리로 게시글 조회
// N번의 쿼리로 각 게시글의 Member 조회 (N+1 문제)
```

**해결 방법**
```java
// Fetch Join 적용
@Query("SELECT a FROM Article a JOIN FETCH a.member ORDER BY a.createdDate DESC")
List findAllWithMember();
// 1번의 쿼리로 게시글과 Member를 함께 조회
```

**효과**
- 쿼리 수: 1 + N → 1개로 감소


<br>

---
### **키워드 과제 정리내용**


<br>

---

## 🚨 참고 사항
